### PR TITLE
Support vhost certificates by using SNI to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Certinel also provides a simple one-page monitoring page were you can add, remov
 
 ## Building
 
-    go get github.com/jteeuwen/go-bindata
+    go get -u github.com/jteeuwen/go-bindata/...
     go get github.com/drtoful/certinel
     go generate github.com/drtoful/certinel
     go install github.com/drtoful/certinel

--- a/app/domain.go
+++ b/app/domain.go
@@ -146,7 +146,8 @@ func (d *Domain) GetCertificate() (*x509.Certificate, error) {
 	}
 
 	conn := tls.Client(c, &tls.Config{
-		InsecureSkipVerify: true, // we check expiration and hostname afterwars, we're only interested in the presented certificate
+		InsecureSkipVerify: true,     // we check expiration and hostname afterwars, we're only interested in the presented certificate
+		ServerName:         d.Domain, // Set the ServerName to support checking vHost certs using SNI
 	})
 	if conn == nil {
 		return nil, err


### PR DESCRIPTION
certinel is unable to get the correct cert if vhosts in the web server are used to serve up different certificates since using InsecureSkipVerify causes the ServerName in tls.Config to == "", which means the web server will serve up the default cert, or none at all if one isn't configured.

By explicitly adding the tls.Config.ServerName = d.Domain line, we cause the tls client to send the ServerName on connection so that the web server can use SNI to determine the correct cert to serve.