### PR TITLE
Adding prometheus metric endpoint at /metrics

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -26,6 +26,14 @@
 		{
 			"ImportPath": "github.com/miekg/dns",
 			"Rev": "5a357a6fc5e85268b929350aa6423e2d56dcc4ff"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_golang/prometheus",
+			"Rev": "5cec1d0429b02e4323e042eb04dafdb079ddf568"
+		},
+		{
+			"ImportPath": "github.com/zbindenren/negroni-prometheus",
+			"Rev": "fc4e664b054e13e568e6cacd913d8d238545d88b"
 		}
 	]
 }

--- a/app/domain.go
+++ b/app/domain.go
@@ -30,21 +30,21 @@ var (
 			Name: "certificate_expiration",
 			Help: "Time to certifiate expiration in seconds",
 		},
-		[]string{"domain"},
+		[]string{"domain", "port"},
 	)
 	certificateSuccess = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "certificate_success",
 			Help: "Count of successes retrieving certificate",
 		},
-		[]string{"domain"},
+		[]string{"domain", "port"},
 	)
 	certificateError = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "certificate_error",
 			Help: "Count of errors retrieving certificate",
 		},
-		[]string{"domain"},
+    []string{"domain", "port"},
 	)
 )
 
@@ -393,15 +393,15 @@ func CheckDomain(domain, port string) {
 			log.Printf("checking domain \"%s:%s\": %s\n", domain, port, err.Error())
 			status.Valid = false
 			status.Err = err.Error()
-			certificateError.With(prometheus.Labels{"domain": d.Domain}).Inc()
+			certificateError.With(prometheus.Labels{"domain": d.Domain, "port": d.Port}).Inc()
 		} else {
 			now := time.Now().UTC().Unix()
 			validity := d.cert.NotAfter.Unix() - now
 			status.Valid = true
 			status.Validity = int(validity / 86400)
 			log.Printf("checking domain \"%s:%s\": certificate is valid for %d days", domain, port, status.Validity)
-			certificateExpiration.With(prometheus.Labels{"domain": d.Domain}).Set(float64(validity))
-			certificateSuccess.With(prometheus.Labels{"domain": d.Domain}).Inc()
+			certificateExpiration.With(prometheus.Labels{"domain": d.Domain, "port": d.Port}).Set(float64(validity))
+			certificateSuccess.With(prometheus.Labels{"domain": d.Domain, "port": d.Port}).Inc()
 		}
 		status.Duration = int64(time.Since(start) / time.Millisecond)
 

--- a/app/http.go
+++ b/app/http.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/drtoful/certinel/Godeps/_workspace/src/github.com/codegangsta/negroni"
 	"github.com/drtoful/certinel/Godeps/_workspace/src/github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/zbindenren/negroni-prometheus"
 )
 
 var (
@@ -172,8 +174,11 @@ func StartAPIServer(port string) {
 	api.Path("/certs").Methods("GET").HandlerFunc(getDomainCerts)
 
 	router.Path("/").Methods("GET").HandlerFunc(getIndex)
+	router.Path("/metrics").Methods("GET").HandlerFunc(promhttp.Handler().ServeHTTP)
 
 	n := negroni.New(negroni.NewRecovery())
+	m := negroniprometheus.NewMiddleware("certinel")
 	n.UseHandler(router)
+	n.Use(m)
 	n.Run(":" + port)
 }


### PR DESCRIPTION
I've added dependencies and code to export prometheus metrics reflecting seconds until certificate expiration, number of successes and errors per domain monitored. 

Attached is a screenshot of certinel functioning as normal, and below are a selection of the metrics that have been exported at /metrics for prometheus to scrape. Additionally quite a few metrics were added regarding application performance as well, as part of the middleware. 

```
# HELP certificate_error Count of errors retrieving certificate
# TYPE certificate_error counter
certificate_error{domain="myfakedomainthtafails.com", port="443"} 1
# HELP certificate_expiration Time to certifiate expiration in seconds
# TYPE certificate_expiration gauge
certificate_expiration{domain="google.com", port="443"} 6.072801e+06
# HELP certificate_success Count of successes retrieving certificate
# TYPE certificate_success counter
certificate_success{domain="google.com", port="443"} 1
```

![image](https://user-images.githubusercontent.com/1444401/32822282-5dde9aec-c99d-11e7-802e-2d839e6945f4.png)